### PR TITLE
Create GitHub Pages website for Encrypted Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Encrypted-Execution-Website
 Website for Encrypted Execution
+
+## Accessing the GitHub Pages Website
+
+You can access the GitHub Pages website for this project at the following URL:
+[Encrypted Execution Website](https://encrypted-execution.com)
+
+## PDF Whitepaper
+
+The PDF whitepaper is available on the website. You can view it directly on the website or download it using the provided link.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Encrypted Execution Whitepaper</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Encrypted Execution Whitepaper</h1>
+    </header>
+    <main>
+        <section>
+            <h2>Whitepaper</h2>
+            <embed src="whitepaper.pdf" type="application/pdf" width="100%" height="600px" />
+            <p><a href="whitepaper.pdf" download>Download the whitepaper</a></p>
+        </section>
+    </main>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,51 @@
+body {
+    font-family: Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 10px 0;
+    text-align: center;
+}
+
+h1 {
+    margin: 0;
+    font-size: 2em;
+}
+
+main {
+    padding: 20px;
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: #fff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+section {
+    margin-bottom: 20px;
+}
+
+h2 {
+    font-size: 1.5em;
+    margin-bottom: 10px;
+}
+
+p {
+    margin: 10px 0;
+}
+
+a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
Add a GitHub Pages website to host a PDF whitepaper with a simple, clean aesthetic.

* **index.html**
  - Create a basic HTML structure with a title "Encrypted Execution Whitepaper"
  - Add an embedded PDF viewer to display `whitepaper.pdf`
  - Include a link to download the `whitepaper.pdf`

* **style.css**
  - Add CSS rules to ensure a simple, clean aesthetic
  - Use a readable font and appropriate font size for accessibility
  - Ensure proper spacing and alignment for a clean layout

* **README.md**
  - Update the description to include instructions on how to access the GitHub Pages website
  - Add a link to the GitHub Pages website
  - Mention the availability of the PDF whitepaper on the website

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/archisgore/Encrypted-Execution-Website/pull/1?shareId=33ffa18c-b6c8-4b11-83ba-7f75e7fb4349).